### PR TITLE
Fix reach check for players without characters (e.g., god mode)

### DIFF
--- a/utilities.lua
+++ b/utilities.lua
@@ -176,6 +176,11 @@ function get_area_under_entity_at_position(entity, position)
 end
 
 function is_within_reach(player, area)
+    -- Fix reach check for players without characters (e.g., god mode)
+     if not player.character or not player.character.valid then
+        return true -- or handle this case differently if needed
+    end
+    
     local player_position = player.position
     local reach = player.character.reach_distance or 0
 


### PR DESCRIPTION
Updated the `is_within_reach` function in `utilities.lua` to handle cases where a player may not have a valid character (e.g., god mode or non-standard modes).

The function now returns `true` if there is no character, preventing errors when calculating distance and reach.