### PR TITLE
Use LuaTilePrototype::items_to_place_this instead of LuaTilePrototype::placeable_by

### DIFF
--- a/utilities.lua
+++ b/utilities.lua
@@ -313,8 +313,6 @@ function get_placeable_items()
                         items[prototype.name] = item.name
                     end
                 end
-            else
-                items[prototype.name] = prototype.items_to_place_this
             end
         end
     end

--- a/utilities.lua
+++ b/utilities.lua
@@ -314,7 +314,7 @@ function get_placeable_items()
                     end
                 end
             else
-                items[prototype.name] = prototype.placeable_by
+                items[prototype.name] = prototype.items_to_place_this
             end
         end
     end


### PR DESCRIPTION
Hi, Factorio dev here. I discovered that `LuaTilePrototype::items_to_place_this` and `LuaTilePrototype::placeable_by` do the exact same thing. I'd like to remove one of these properties. This mod is the only mod on the mod portal using `LuaTilePrototype::placeable_by`. So we will most likely remove placeable_by in the next Factorio version.

This pull request will get your mod ready for this Factorio change. You can already merge this code and release it now since the other property already exists and will continue to exist.